### PR TITLE
Feature implementation from commits 92def3b..7bfd96a

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.40.1
+go get github.com/nats-io/nats.go@v1.41.0
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A [Go](http://golang.org) client for the [NATS messaging system](https://nats.io
 go get github.com/nats-io/nats.go@latest
 
 # To get a specific version:
-go get github.com/nats-io/nats.go@v1.41.0
+go get github.com/nats-io/nats.go@v1.41.1
 
 # Note that the latest major version for NATS Server is v2:
 go get github.com/nats-io/nats-server/v2@latest

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/nats-io/nkeys v0.4.9
 	github.com/nats-io/nuid v1.0.1
-	golang.org/x/text v0.23.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,3 @@ golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=

--- a/jetstream/api.go
+++ b/jetstream/api.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 The NATS Authors
+// Copyright 2022-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -104,6 +104,9 @@ const (
 
 	// apiMsgDeleteT is the endpoint to remove a message.
 	apiMsgDeleteT = "STREAM.MSG.DELETE.%s"
+
+	// apiConsumerUnpinT is the endpoint to unpin a consumer.
+	apiConsumerUnpinT = "CONSUMER.UNPIN.%s.%s"
 )
 
 func (js *jetStream) apiRequestJSON(ctx context.Context, subject string, resp any, data ...[]byte) (*jetStreamMsg, error) {

--- a/jetstream/consumer_config.go
+++ b/jetstream/consumer_config.go
@@ -76,12 +76,26 @@ type (
 		// TimeStamp indicates when the info was gathered by the server.
 		TimeStamp time.Time `json:"ts"`
 
+		// PriorityGroups contains the information about the currently defined priority groups
+		PriorityGroups []PriorityGroupState `json:"priority_groups,omitempty"`
+
 		// Paused indicates whether the consumer is paused.
 		Paused bool `json:"paused,omitempty"`
 
 		// PauseRemaining contains the amount of time left until the consumer
 		// unpauses. It will only be non-zero if the consumer is currently paused.
 		PauseRemaining time.Duration `json:"pause_remaining,omitempty"`
+	}
+
+	PriorityGroupState struct {
+		// Group this status is for.
+		Group string `json:"group"`
+
+		// PinnedClientID is the generated ID of the pinned client.
+		PinnedClientID string `json:"pinned_client_id,omitempty"`
+
+		// PinnedTS is the timestamp when the client was pinned.
+		PinnedTS time.Time `json:"pinned_ts,omitempty"`
 	}
 
 	// ConsumerConfig is the configuration of a JetStream consumer.
@@ -227,6 +241,18 @@ type (
 
 		// PauseUntil is for suspending the consumer until the deadline.
 		PauseUntil *time.Time `json:"pause_until,omitempty"`
+
+		// PriorityPolicy represents he priority policy the consumer is set to.
+		// Requires nats-server v2.11.0 or later.
+		PriorityPolicy PriorityPolicy `json:"priority_policy,omitempty"`
+
+		// PinnedTTL represents the time after which the client will be unpinned
+		// if no new pull requests are sent.Used with PriorityPolicyPinned.
+		// Requires nats-server v2.11.0 or later.
+		PinnedTTL time.Duration `json:"priority_timeout,omitempty"`
+
+		// PriorityGroups is a list of priority groups this consumer supports.
+		PriorityGroups []string `json:"priority_groups,omitempty"`
 	}
 
 	// OrderedConsumerConfig is the configuration of an ordered JetStream
@@ -298,7 +324,50 @@ type (
 		Stream   uint64     `json:"stream_seq"`
 		Last     *time.Time `json:"last_active,omitempty"`
 	}
+
+	// PriorityPolicy determines the priority policy the consumer is set to.
+	PriorityPolicy int
 )
+
+const (
+	// PriorityPolicyNone is the default priority policy.
+	PriorityPolicyNone PriorityPolicy = iota
+
+	// PriorityPolicyPinned is the priority policy that pins a consumer to a
+	// specific client.
+	PriorityPolicyPinned
+
+	// PriorityPolicyOverflow is the priority policy that allows for
+	// restricting when a consumer will receive messages based on the number of
+	// pending messages or acks.
+	PriorityPolicyOverflow
+)
+
+func (p *PriorityPolicy) UnmarshalJSON(data []byte) error {
+	switch string(data) {
+	case jsonString(""):
+		*p = PriorityPolicyNone
+	case jsonString("pinned_client"):
+		*p = PriorityPolicyPinned
+	case jsonString("overflow"):
+		*p = PriorityPolicyOverflow
+	default:
+		return fmt.Errorf("nats: can not unmarshal %q", data)
+	}
+	return nil
+}
+
+func (p PriorityPolicy) MarshalJSON() ([]byte, error) {
+	switch p {
+	case PriorityPolicyNone:
+		return json.Marshal("")
+	case PriorityPolicyPinned:
+		return json.Marshal("pinned_client")
+	case PriorityPolicyOverflow:
+		return json.Marshal("overflow")
+	}
+	return nil, fmt.Errorf("nats: unknown priority policy %v", p)
+}
 
 const (
 	// DeliverAllPolicy starts delivering messages from the very beginning of a

--- a/jetstream/consumer_config.go
+++ b/jetstream/consumer_config.go
@@ -263,7 +263,7 @@ type (
 
 		// InactiveThreshold is a duration which instructs the server to clean
 		// up the consumer if it has been inactive for the specified duration.
-		// Defaults to 5s.
+		// Defaults to 5m.
 		InactiveThreshold time.Duration `json:"inactive_threshold,omitempty"`
 
 		// HeadersOnly indicates whether only headers of messages should be sent

--- a/jetstream/errors.go
+++ b/jetstream/errors.go
@@ -195,6 +195,10 @@ var (
 	// consumer.
 	ErrNoMessages JetStreamError = &jsError{message: "no messages"}
 
+	// ErrPinIDMismatch is returned when Pin ID sent in the request does not match
+	// the currently pinned consumer subscriber ID on the server.
+	ErrPinIDMismatch JetStreamError = &jsError{message: "pin ID mismatch"}
+
 	// ErrMaxBytesExceeded is returned when a message would exceed MaxBytes set
 	// on a pull request.
 	ErrMaxBytesExceeded JetStreamError = &jsError{message: "message size exceeds max bytes"}

--- a/jetstream/jetstream.go
+++ b/jetstream/jetstream.go
@@ -304,11 +304,6 @@ type (
 		// Domain is the domain name token used when sending JetStream requests.
 		Domain string
 
-		// DefaultTimeout is the default timeout used for JetStream API requests.
-		// This applies when the context passed to JetStream methods does not have
-		// a deadline set.
-		DefaultTimeout time.Duration
-
 		publisherOpts asyncPublisherOpts
 
 		// this is the actual prefix used in the API requests
@@ -412,7 +407,6 @@ func New(nc *nats.Conn, opts ...JetStreamOpt) (JetStream, error) {
 		publisherOpts: asyncPublisherOpts{
 			maxpa: defaultAsyncPubAckInflight,
 		},
-		DefaultTimeout: defaultAPITimeout,
 	}
 	setReplyPrefix(nc, &jsOpts)
 	for _, opt := range opts {
@@ -457,8 +451,7 @@ func NewWithAPIPrefix(nc *nats.Conn, apiPrefix string, opts ...JetStreamOpt) (Je
 		publisherOpts: asyncPublisherOpts{
 			maxpa: defaultAsyncPubAckInflight,
 		},
-		APIPrefix:      apiPrefix,
-		DefaultTimeout: defaultAPITimeout,
+		APIPrefix: apiPrefix,
 	}
 	setReplyPrefix(nc, &jsOpts)
 	for _, opt := range opts {
@@ -495,8 +488,7 @@ func NewWithDomain(nc *nats.Conn, domain string, opts ...JetStreamOpt) (JetStrea
 		publisherOpts: asyncPublisherOpts{
 			maxpa: defaultAsyncPubAckInflight,
 		},
-		Domain:         domain,
-		DefaultTimeout: defaultAPITimeout,
+		Domain: domain,
 	}
 	setReplyPrefix(nc, &jsOpts)
 	for _, opt := range opts {
@@ -1097,7 +1089,7 @@ func (js *jetStream) wrapContextWithoutDeadline(ctx context.Context) (context.Co
 	if _, ok := ctx.Deadline(); ok {
 		return ctx, nil
 	}
-	return context.WithTimeout(ctx, js.opts.DefaultTimeout)
+	return context.WithTimeout(ctx, defaultAPITimeout)
 }
 
 // CleanupPublisher will cleanup the publishing side of JetStreamContext.

--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -297,6 +297,73 @@ func (t PullThresholdBytes) configureMessages(opts *consumeOpts) error {
 	return nil
 }
 
+// PullMinPending sets the minimum number of messages that should be pending for
+// a consumer with PriorityPolicyOverflow to be considered for delivery.
+// If provided, PullPriorityGroup must be set as well and the consumer has to have
+// PriorityPolicy set to PriorityPolicyOverflow.
+//
+// PullMinPending implements both PullConsumeOpt and PullMessagesOpt, allowing
+// it to configure Consumer.Consume and Consumer.Messages.
+type PullMinPending int
+
+func (min PullMinPending) configureConsume(opts *consumeOpts) error {
+	if min < 1 {
+		return fmt.Errorf("%w: min pending should be more than 0", ErrInvalidOption)
+	}
+	opts.MinPending = int64(min)
+	return nil
+}
+
+func (min PullMinPending) configureMessages(opts *consumeOpts) error {
+	if min < 1 {
+		return fmt.Errorf("%w: min pending should be more than 0", ErrInvalidOption)
+	}
+	opts.MinPending = int64(min)
+	return nil
+}
+
+// PullMinAckPending sets the minimum number of pending acks that should be
+// present for a consumer with PriorityPolicyOverflow to be considered for
+// delivery. If provided, PullPriorityGroup must be set as well and the consumer
+// has to have PriorityPolicy set to PriorityPolicyOverflow.
+//
+// PullMinAckPending implements both PullConsumeOpt and PullMessagesOpt, allowing
+// it to configure Consumer.Consume and Consumer.Messages.
+type PullMinAckPending int
+
+func (min PullMinAckPending) configureConsume(opts *consumeOpts) error {
+	if min < 1 {
+		return fmt.Errorf("%w: min pending should be more than 0", ErrInvalidOption)
+	}
+	opts.MinAckPending = int64(min)
+	return nil
+}
+
+func (min PullMinAckPending) configureMessages(opts *consumeOpts) error {
+	if min < 1 {
+		return fmt.Errorf("%w: min pending should be more than 0", ErrInvalidOption)
+	}
+	opts.MinAckPending = int64(min)
+	return nil
+}
+
+// PullPriorityGroup sets the priority group for a consumer.
+// It has to match one of the priority groups set on the consumer.
+//
+// PullPriorityGroup implements both PullConsumeOpt and PullMessagesOpt, allowing
+// it to configure Consumer.Consume and Consumer.Messages.
+type PullPriorityGroup string
+
+func (g PullPriorityGroup) configureConsume(opts *consumeOpts) error {
+	opts.Group = string(g)
+	return nil
+}
+
+func (g PullPriorityGroup) configureMessages(opts *consumeOpts) error {
+	opts.Group = string(g)
+	return nil
+}
+
 // PullHeartbeat sets the idle heartbeat duration for a pull subscription
 // If a client does not receive a heartbeat message from a stream for more
 // than the idle heartbeat setting, the subscription will be removed
@@ -366,6 +433,43 @@ func WithMessagesErrOnMissingHeartbeat(hbErr bool) PullMessagesOpt {
 		cfg.ReportMissingHeartbeats = hbErr
 		return nil
 	})
+}
+
+// FetchMinPending sets the minimum number of messages that should be pending for
+// a consumer with PriorityPolicyOverflow to be considered for delivery.
+// If provided, FetchPriorityGroup must be set as well and the consumer has to have
+// PriorityPolicy set to PriorityPolicyOverflow.
+func FetchMinPending(min int64) FetchOpt {
+	return func(req *pullRequest) error {
+		if min < 1 {
+			return fmt.Errorf("%w: min pending should be more than 0", ErrInvalidOption)
+		}
+		req.MinPending = min
+		return nil
+	}
+}
+
+// FetchMinAckPending sets the minimum number of pending acks that should be
+// present for a consumer with PriorityPolicyOverflow to be considered for
+// delivery. If provided, FetchPriorityGroup must be set as well and the consumer
+// has to have PriorityPolicy set to PriorityPolicyOverflow.
+func FetchMinAckPending(min int64) FetchOpt {
+	return func(req *pullRequest) error {
+		if min < 1 {
+			return fmt.Errorf("%w: min ack pending should be more than 0", ErrInvalidOption)
+		}
+		req.MinAckPending = min
+		return nil
+	}
+}
+
+// FetchPriorityGroup sets the priority group for a consumer.
+// It has to match one of the priority groups set on the consumer.
+func FetchPriorityGroup(group string) FetchOpt {
+	return func(req *pullRequest) error {
+		req.Group = group
+		return nil
+	}
 }
 
 // FetchMaxWait sets custom timeout for fetching predefined batch of messages.

--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -65,19 +65,6 @@ func WithPublishAsyncTimeout(dur time.Duration) JetStreamOpt {
 	}
 }
 
-// WithDefaultTimeout sets the default timeout for JetStream API requests.
-// It is used when context used for the request does not have a deadline set.
-// If not provided, a default of 5 seconds will be used.
-func WithDefaultTimeout(timeout time.Duration) JetStreamOpt {
-	return func(opts *JetStreamOptions) error {
-		if timeout <= 0 {
-			return fmt.Errorf("%w: timeout value must be greater than 0", ErrInvalidOption)
-		}
-		opts.DefaultTimeout = timeout
-		return nil
-	}
-}
-
 // WithPurgeSubject sets a specific subject for which messages on a stream will
 // be purged
 func WithPurgeSubject(subject string) StreamPurgeOpt {

--- a/jetstream/jetstream_options.go
+++ b/jetstream/jetstream_options.go
@@ -65,6 +65,19 @@ func WithPublishAsyncTimeout(dur time.Duration) JetStreamOpt {
 	}
 }
 
+// WithDefaultTimeout sets the default timeout for JetStream API requests.
+// It is used when context used for the request does not have a deadline set.
+// If not provided, a default of 5 seconds will be used.
+func WithDefaultTimeout(timeout time.Duration) JetStreamOpt {
+	return func(opts *JetStreamOptions) error {
+		if timeout <= 0 {
+			return fmt.Errorf("%w: timeout value must be greater than 0", ErrInvalidOption)
+		}
+		opts.DefaultTimeout = timeout
+		return nil
+	}
+}
+
 // WithPurgeSubject sets a specific subject for which messages on a stream will
 // be purged
 func WithPurgeSubject(subject string) StreamPurgeOpt {

--- a/jetstream/message.go
+++ b/jetstream/message.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The NATS Authors
+// Copyright 2022-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -147,6 +147,7 @@ const (
 	reqTimeout       = "408"
 	maxBytesExceeded = "409"
 	noResponders     = "503"
+	pinIdMismatch    = "423"
 )
 
 // Headers used when publishing messages.
@@ -418,6 +419,8 @@ func checkMsg(msg *nats.Msg) (bool, error) {
 		return false, nats.ErrTimeout
 	case controlMsg:
 		return false, nil
+	case pinIdMismatch:
+		return false, ErrPinIDMismatch
 	case maxBytesExceeded:
 		if strings.Contains(strings.ToLower(descr), "message size exceeds maxbytes") {
 			return false, ErrMaxBytesExceeded

--- a/jetstream/object.go
+++ b/jetstream/object.go
@@ -488,7 +488,7 @@ const (
 )
 
 func (js *jetStream) CreateObjectStore(ctx context.Context, cfg ObjectStoreConfig) (ObjectStore, error) {
-	scfg, err := js.prepareObjectStoreConfig(ctx, cfg)
+	scfg, err := js.prepareObjectStoreConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +511,7 @@ func (js *jetStream) CreateObjectStore(ctx context.Context, cfg ObjectStoreConfi
 }
 
 func (js *jetStream) UpdateObjectStore(ctx context.Context, cfg ObjectStoreConfig) (ObjectStore, error) {
-	scfg, err := js.prepareObjectStoreConfig(ctx, cfg)
+	scfg, err := js.prepareObjectStoreConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +533,7 @@ func (js *jetStream) UpdateObjectStore(ctx context.Context, cfg ObjectStoreConfi
 }
 
 func (js *jetStream) CreateOrUpdateObjectStore(ctx context.Context, cfg ObjectStoreConfig) (ObjectStore, error) {
-	scfg, err := js.prepareObjectStoreConfig(ctx, cfg)
+	scfg, err := js.prepareObjectStoreConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +550,7 @@ func (js *jetStream) CreateOrUpdateObjectStore(ctx context.Context, cfg ObjectSt
 	return mapStreamToObjectStore(js, pushJS, cfg.Bucket, stream), nil
 }
 
-func (js *jetStream) prepareObjectStoreConfig(ctx context.Context, cfg ObjectStoreConfig) (StreamConfig, error) {
+func (js *jetStream) prepareObjectStoreConfig(cfg ObjectStoreConfig) (StreamConfig, error) {
 	if !validBucketRe.MatchString(cfg.Bucket) {
 		return StreamConfig{}, ErrInvalidStoreName
 	}
@@ -824,6 +824,7 @@ func (info *ObjectInfo) isLink() bool {
 
 // Get will pull the object from the underlying stream.
 func (obs *obs) Get(ctx context.Context, name string, opts ...GetObjectOpt) (ObjectResult, error) {
+	ctx, cancel := obs.js.wrapContextWithoutDeadline(ctx)
 	var o getObjectOpts
 	for _, opt := range opts {
 		if opt != nil {
@@ -933,10 +934,15 @@ func (obs *obs) Get(ctx context.Context, name string, opts ...GetObjectOpt) (Obj
 		nats.Context(ctx),
 		nats.BindStream(streamName),
 	}
-	_, err = obs.pushJS.Subscribe(chunkSubj, processChunk, subscribeOpts...)
+	sub, err := obs.pushJS.Subscribe(chunkSubj, processChunk, subscribeOpts...)
 	if err != nil {
 		return nil, err
 	}
+	sub.SetClosedHandler(func(subject string) {
+		if cancel != nil {
+			cancel()
+		}
+	})
 
 	return result, nil
 }

--- a/jetstream/object.go
+++ b/jetstream/object.go
@@ -1330,6 +1330,9 @@ func (obs *obs) Watch(ctx context.Context, opts ...WatchOpt) (ObjectWatcher, err
 	if err != nil {
 		return nil, err
 	}
+	sub.SetClosedHandler(func(_ string) {
+		close(w.updates)
+	})
 	w.sub = sub
 	return w, nil
 }

--- a/jetstream/stream.go
+++ b/jetstream/stream.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 The NATS Authors
+// Copyright 2022-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -114,6 +114,10 @@ type (
 		// ConsumerNames returns a ConsumerNameLister enabling iterating over a
 		// channel of consumer names.
 		ConsumerNames(context.Context) ConsumerNameLister
+
+		// UnpinConsumer unpins the currently pinned client for a consumer for the given group name.
+		// If consumer does not exist, ErrConsumerNotFound is returned.
+		UnpinConsumer(ctx context.Context, consumer string, group string) error
 	}
 
 	RawStreamMsg struct {
@@ -257,6 +261,10 @@ type (
 		apiResponse
 		apiPaged
 		Consumers []string `json:"consumers"`
+	}
+
+	consumerUnpinRequest struct {
+		Group string `json:"group"`
 	}
 )
 
@@ -749,4 +757,10 @@ func (s *consumerLister) consumerNames(ctx context.Context, stream string) ([]st
 	s.pageInfo = &resp.apiPaged
 	s.offset += len(resp.Consumers)
 	return resp.Consumers, nil
+}
+
+// UnpinConsumer unpins the currently pinned client for a consumer for the given group name.
+// If consumer does not exist, ErrConsumerNotFound is returned.
+func (s *stream) UnpinConsumer(ctx context.Context, consumer string, group string) error {
+	return unpinConsumer(ctx, s.js, s.name, consumer, group)
 }

--- a/jetstream/stream_config.go
+++ b/jetstream/stream_config.go
@@ -19,9 +19,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type (
@@ -528,12 +525,11 @@ const (
 )
 
 func (st StorageType) String() string {
-	caser := cases.Title(language.AmericanEnglish)
 	switch st {
 	case MemoryStorage:
-		return caser.String(memoryStorageString)
+		return "Memory"
 	case FileStorage:
-		return caser.String(fileStorageString)
+		return "File"
 	default:
 		return "Unknown Storage Type"
 	}

--- a/jetstream/test/consumer_test.go
+++ b/jetstream/test/consumer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The NATS Authors
+// Copyright 2023-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -16,6 +16,8 @@ package test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -125,6 +127,1013 @@ func TestConsumerInfo(t *testing.T) {
 		_, err = c.Info(ctx)
 		if err == nil || !errors.Is(err, jetstream.ErrConsumerNotFound) {
 			t.Fatalf("Expected error: %v; got: %v", jetstream.ErrConsumerNotFound, err)
+		}
+	})
+}
+
+func TestConsumerOverflow(t *testing.T) {
+	t.Run("fetch", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			PriorityPolicy: jetstream.PriorityPolicyOverflow,
+			PriorityGroups: []string{"A"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Check that consumer got proper priority policy and TTL
+		info := c.CachedInfo()
+		if info.Config.PriorityPolicy != jetstream.PriorityPolicyOverflow {
+			t.Fatalf("Invalid priority policy; expected: %v; got: %v", jetstream.PriorityPolicyOverflow, info.Config.PriorityPolicy)
+		}
+
+		for range 100 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		// We are below overflow, so we should not get any messages.
+		msgs, err := c.Fetch(10, jetstream.FetchMinPending(110), jetstream.FetchMaxWait(500*time.Millisecond), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count := 0
+		for msg := range msgs.Messages() {
+			msg.Ack()
+			count++
+		}
+		if count != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count)
+		}
+
+		// Add more messages
+		for range 100 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		msgs, err = c.Fetch(10, jetstream.FetchMinPending(110), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count = 0
+		for msg := range msgs.Messages() {
+			if err := msg.DoubleAck(context.Background()); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			count++
+		}
+		if count != 10 {
+			t.Fatalf("Expected 10 messages, got %d", count)
+		}
+
+		// try fetching messages with min ack pending
+		msgs, err = c.Fetch(10, jetstream.FetchMaxWait(500*time.Millisecond), jetstream.FetchMinAckPending(10), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count = 0
+		for msg := range msgs.Messages() {
+			msg.Ack()
+			count++
+		}
+		if count != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count)
+		}
+
+		// now fetch some more messages but do not ack them,
+		// we will test min ack pending
+		msgs, err = c.Fetch(10, jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count = 0
+		for range msgs.Messages() {
+			count++
+		}
+		if msgs.Error() != nil {
+			t.Fatalf("Unexpected error: %v", msgs.Error())
+		}
+		if count != 10 {
+			t.Fatalf("Expected 10 messages, got %d", count)
+		}
+
+		// now fetch messages with min ack pending
+		msgs, err = c.Fetch(10, jetstream.FetchMinAckPending(10), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count = 0
+		for msg := range msgs.Messages() {
+			msg.Ack()
+			count++
+		}
+		if msgs.Error() != nil {
+			t.Fatalf("Unexpected error: %v", msgs.Error())
+		}
+		if count != 10 {
+			t.Fatalf("Expected 10 messages, got %d", count)
+		}
+	})
+
+	t.Run("consume", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			PriorityPolicy: jetstream.PriorityPolicyOverflow,
+			PriorityGroups: []string{"A"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Check that consumer got proper priority policy and TTL
+		info := c.CachedInfo()
+		if info.Config.PriorityPolicy != jetstream.PriorityPolicyOverflow {
+			t.Fatalf("Invalid priority policy; expected: %v; got: %v", jetstream.PriorityPolicyOverflow, info.Config.PriorityPolicy)
+		}
+
+		for i := range 100 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte(fmt.Sprintf("hello %d", i)))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		count := atomic.Uint32{}
+
+		handler := func(m jetstream.Msg) {
+			if err := m.Ack(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			count.Add(1)
+		}
+		cc, err := c.Consume(handler,
+			jetstream.PullPriorityGroup("A"),
+			jetstream.PullMinPending(110),
+			jetstream.PullMaxMessages(20),
+			jetstream.PullExpiry(time.Second))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer cc.Stop()
+
+		time.Sleep(3 * time.Second)
+		// there are 100 messages on the stream, and min pending is 110
+		// so we should not get any messages
+		if count.Load() != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count.Load())
+		}
+
+		// Add more messages
+		for i := 100; i < 200; i++ {
+			_, err = js.Publish(ctx, "FOO.bar", []byte(fmt.Sprintf("hello %d", i)))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		// now we should get 91 messages, because `Consume` will
+		// keep getting messages until it drops below min pending
+		if count.Load() != 91 {
+			t.Fatalf("Expected 10 messages, got %d", count.Load())
+		}
+		cc.Stop()
+
+		// now test min ack pending
+		count.Store(0)
+
+		// consume with min ack pending
+		cc, err = c.Consume(handler,
+			jetstream.PullPriorityGroup("A"),
+			jetstream.PullMinAckPending(5),
+			jetstream.PullMaxMessages(20))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer cc.Stop()
+
+		time.Sleep(100 * time.Millisecond)
+		// no messages should be received, there are no pending acks
+		if count.Load() != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count.Load())
+		}
+		// fetch some messages, do not ack them
+		msgs, err := c.Fetch(10, jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		i := 0
+		for range msgs.Messages() {
+			i++
+		}
+		if msgs.Error() != nil {
+			t.Fatalf("Unexpected error: %v", msgs.Error())
+		}
+		if i != 10 {
+			t.Fatalf("Expected 10 messages, got %d", i)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		// we should process the rest of the stream minus the 10 unacked messages
+		// 200 - 91 - 10 = 99
+		if count.Load() != 99 {
+			t.Fatalf("Expected 5 messages, got %d", count.Load())
+		}
+	})
+
+	t.Run("messages", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			PriorityPolicy: jetstream.PriorityPolicyOverflow,
+			PriorityGroups: []string{"A"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Check that consumer got proper priority policy and TTL
+		info := c.CachedInfo()
+		if info.Config.PriorityPolicy != jetstream.PriorityPolicyOverflow {
+			t.Fatalf("Invalid priority policy; expected: %v; got: %v", jetstream.PriorityPolicyOverflow, info.Config.PriorityPolicy)
+		}
+
+		for i := range 100 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte(fmt.Sprintf("hello %d", i)))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		count := atomic.Uint32{}
+		errs := make(chan error, 10)
+		done := make(chan struct{}, 1)
+		handler := func(it jetstream.MessagesContext) {
+			for {
+				msg, err := it.Next()
+				if err != nil {
+					if !errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+						errs <- err
+					}
+					break
+				}
+				if err := msg.Ack(); err != nil {
+					errs <- err
+					break
+				}
+				count.Add(1)
+			}
+			done <- struct{}{}
+		}
+
+		it, err := c.Messages(jetstream.PullPriorityGroup("A"),
+			jetstream.PullMinPending(110),
+			jetstream.PullMaxMessages(20))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		go handler(it)
+
+		time.Sleep(100 * time.Millisecond)
+		// there are 100 messages on the stream, and min pending is 110
+		// so we should not get any messages
+		if count.Load() != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count.Load())
+		}
+
+		// Add more messages
+		for i := 100; i < 200; i++ {
+			_, err = js.Publish(ctx, "FOO.bar", []byte(fmt.Sprintf("hello %d", i)))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		// now we should get 91 messages, because `Consume` will
+		// keep getting messages until it drops below min pending
+		if count.Load() != 91 {
+			t.Fatalf("Expected 10 messages, got %d", count.Load())
+		}
+		it.Stop()
+		<-done
+
+		// now test min ack pending
+		count.Store(0)
+
+		it, err = c.Messages(jetstream.PullPriorityGroup("A"),
+			jetstream.PullMinAckPending(5),
+			jetstream.PullMaxMessages(20))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		go handler(it)
+
+		time.Sleep(100 * time.Millisecond)
+		// no messages should be received, there are no pending acks
+		if count.Load() != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count.Load())
+		}
+		// fetch some messages, do not ack them
+		msgs, err := c.Fetch(10, jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		i := 0
+		for range msgs.Messages() {
+			i++
+		}
+		if msgs.Error() != nil {
+			t.Fatalf("Unexpected error: %v", msgs.Error())
+		}
+		if i != 10 {
+			t.Fatalf("Expected 10 messages, got %d", i)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+		// we should process the rest of the stream minus the 10 unacked messages
+		// 200 - 91 - 10 = 99
+		if count.Load() != 99 {
+			t.Fatalf("Expected 5 messages, got %d", count.Load())
+		}
+		it.Stop()
+		<-done
+	})
+}
+
+func TestConsumerPinned(t *testing.T) {
+	t.Run("messages", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			Durable:        "cons",
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			Description:    "test consumer",
+			PriorityPolicy: jetstream.PriorityPolicyPinned,
+			PinnedTTL:      time.Second,
+			PriorityGroups: []string{"A"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		for range 1000 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		gcount := make(chan struct{}, 1000)
+		count := atomic.Uint32{}
+
+		// Initially pinned consumer instance
+		initiallyPinned, err := s.Consumer(ctx, "cons")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		handler := func(it jetstream.MessagesContext, counter *atomic.Uint32, doneCh chan struct{}) {
+			for {
+				msg, err := it.Next()
+				if err != nil {
+					break
+				}
+				if err := msg.Ack(); err != nil {
+					break
+				}
+				counter.Add(1)
+				gcount <- struct{}{}
+			}
+			doneCh <- struct{}{}
+		}
+		// test priority group validation
+		// invalid priority group
+		_, err = initiallyPinned.Messages(jetstream.PullPriorityGroup("BAD"))
+		if err == nil || err.Error() != "nats: invalid jetstream option: invalid priority group" {
+			t.Fatalf("Expected invalid priority group error, got %v", err)
+		}
+
+		// no priority group
+		_, err = initiallyPinned.Messages()
+		if err == nil || err.Error() != "nats: invalid jetstream option: priority group is required for priority consumer" {
+			t.Fatalf("Expected invalid priority group error")
+		}
+
+		ipDoneCh := make(chan struct{})
+		ip, err := initiallyPinned.Messages(jetstream.PullPriorityGroup("A"), jetstream.PullHeartbeat(500*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer ip.Stop()
+
+		_, err = ip.Next()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count.Store(1)
+		go handler(ip, &count, ipDoneCh)
+
+		time.Sleep(100 * time.Millisecond)
+
+		// Second consume instance that should remain passive.
+		notPinnedC := atomic.Uint32{}
+		npDoneCh := make(chan struct{})
+		np, err := c.Messages(jetstream.PullPriorityGroup("A"), jetstream.PullHeartbeat(500*time.Millisecond))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer np.Stop()
+		go handler(np, &notPinnedC, npDoneCh)
+
+		waitForCounter := func(t *testing.T, c *atomic.Uint32, expected int) {
+			t.Helper()
+
+		outer:
+			for {
+				select {
+				case <-gcount:
+					if c.Load() == uint32(expected) {
+						break outer
+					}
+				case <-time.After(10 * time.Second):
+					t.Fatalf("Did not get all messages in time; expected %d, got %d", expected, c.Load())
+				}
+			}
+		}
+
+		waitForCounter(t, &count, 1000)
+		if notPinnedC.Load() != 0 {
+			t.Fatalf("Expected 0 messages for not pinned, got %d", notPinnedC.Load())
+		}
+
+		count.Store(0)
+		ip.Stop()
+		for range 100 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+		if notPinnedC.Load() != 0 {
+			t.Fatalf("Expected 0 messages for not pinned, got %d", notPinnedC.Load())
+		}
+
+		//wait for pinned ttl to expire and messages to be consumed by the second consumer
+		waitForCounter(t, &notPinnedC, 100)
+		if count.Load() != 0 {
+			t.Fatalf("Expected 0 messages for pinned, got %d", count.Load())
+		}
+		np.Stop()
+		select {
+		case <-ipDoneCh:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Expected pinned consumer to be done")
+		}
+		select {
+		case <-npDoneCh:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Expected not pinned consumer to be done")
+		}
+	})
+
+	t.Run("consume", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			Durable:        "cons",
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			Description:    "test consumer",
+			PriorityPolicy: jetstream.PriorityPolicyPinned,
+			PinnedTTL:      1 * time.Second,
+			PriorityGroups: []string{"A"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		for range 1000 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		// Initially pinned consumer instance
+		initiallyPinned, err := s.Consumer(ctx, "cons")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// test priority group validation
+		// invalid priority group
+		_, err = initiallyPinned.Consume(func(m jetstream.Msg) {
+		}, jetstream.PullPriorityGroup("BAD"))
+		if err == nil || err.Error() != "nats: invalid jetstream option: invalid priority group" {
+			t.Fatalf("Expected invalid priority group error")
+		}
+
+		// no priority group
+		_, err = initiallyPinned.Consume(func(m jetstream.Msg) {})
+		if err == nil || err.Error() != "nats: invalid jetstream option: priority group is required for priority consumer" {
+			t.Fatalf("Expected invalid priority group error")
+		}
+
+		pinnedCount := atomic.Uint32{}
+		pinnedDone := make(chan struct{})
+		ip, err := initiallyPinned.Consume(func(m jetstream.Msg) {
+			if err := m.Ack(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if pinnedCount.Add(1) == 1000 {
+				close(pinnedDone)
+			}
+		}, jetstream.PullThresholdMessages(10), jetstream.PullPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer ip.Stop()
+
+		time.Sleep(100 * time.Millisecond)
+
+		// Second consume instance that should remain passive.
+		notPinnedCount := atomic.Uint32{}
+		notPinnedDone := make(chan struct{})
+		np, err := c.Consume(func(m jetstream.Msg) {
+			if err := m.Ack(); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if notPinnedCount.Add(1) == 100 {
+				close(notPinnedDone)
+			}
+
+		}, jetstream.PullPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer np.Stop()
+
+		select {
+		case <-pinnedDone:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("Expected pinned consumer to be done")
+		}
+		if notPinnedCount.Load() != 0 {
+			t.Fatalf("Expected 0 messages for not pinned, got %d", notPinnedCount.Load())
+		}
+
+		pinnedCount.Store(0)
+		ip.Stop()
+		for range 100 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+		if notPinnedCount.Load() != 0 {
+			t.Fatalf("Expected 0 messages for not pinned, got %d", notPinnedCount.Load())
+		}
+
+		//wait for pinned ttl to expire and messages to be consumed by the second consumer
+		select {
+		case <-notPinnedDone:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("Expected not pinned consumer to be done after pinned ttl expired")
+		}
+		if pinnedCount.Load() != 0 {
+			t.Fatalf("Expected 0 messages for pinned, got %d", pinnedCount.Load())
+		}
+	})
+
+	t.Run("fetch", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			Durable:        "cons",
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			Description:    "test consumer",
+			PriorityPolicy: jetstream.PriorityPolicyPinned,
+			PinnedTTL:      time.Second,
+			PriorityGroups: []string{"A"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Check that consumer got proper priority policy and TTL
+		info := c.CachedInfo()
+		if info.Config.PriorityPolicy != jetstream.PriorityPolicyPinned {
+			t.Fatalf("Invalid priority policy; expected: %v; got: %v", jetstream.PriorityPolicyPinned, info.Config.PriorityPolicy)
+		}
+		if info.Config.PinnedTTL != time.Second {
+			t.Fatalf("Invalid pinned TTL; expected: %v; got: %v", time.Second, info.Config.PinnedTTL)
+		}
+
+		for range 100 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		// Initial fetch.
+		// Should get all messages and get a Pin ID.
+		msgs, err := c.Fetch(10, jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count := 0
+		id := ""
+		for msg := range msgs.Messages() {
+			msg.Ack()
+			count++
+			natsMsgId := msg.Headers().Get("Nats-Pin-Id")
+			if id == "" {
+				id = natsMsgId
+			} else {
+				if id != natsMsgId {
+					t.Fatalf("Expected Nats-Msg-Id to be the same for all messages")
+				}
+			}
+		}
+		if count != 10 {
+			t.Fatalf("Expected 10 messages, got %d", count)
+
+		}
+
+		// Different consumer instance.
+		cdiff, err := js.Consumer(ctx, "foo", "cons")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		msgs, err = cdiff.Fetch(10, jetstream.FetchMaxWait(200*time.Millisecond), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		count = 0
+		for msg := range msgs.Messages() {
+			msg.Ack()
+			count++
+		}
+		if count != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count)
+		}
+		if msgs.Error() != nil {
+			t.Fatalf("Unexpected error: %v", msgs.Error())
+		}
+
+		count = 0
+
+		// Now lets fetch from the pinned one, which should be fine.
+		msgs, err = c.Fetch(10, jetstream.FetchMaxWait(3*time.Second), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		for msg := range msgs.Messages() {
+			if pinId := msg.Headers().Get("Nats-Pin-Id"); pinId == "" {
+				t.Fatalf("missing Nats-Pin-Id header")
+			}
+			msg.Ack()
+			count++
+		}
+		if count != 10 {
+			t.Fatalf("Expected 10 messages, got %d", count)
+		}
+		if msgs.Error() != nil {
+			t.Fatalf("Unexpected error: %v", msgs.Error())
+		}
+
+		// Wait for the TTL to expire, expect different ID
+		count = 0
+		time.Sleep(1500 * time.Millisecond)
+		// The same instance, should work fine.
+
+		msgs, err = c.Fetch(10, jetstream.FetchMaxWait(500*time.Millisecond), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		for msg := range msgs.Messages() {
+			msg.Ack()
+			count++
+		}
+		if !errors.Is(msgs.Error(), jetstream.ErrPinIDMismatch) {
+			t.Fatalf("Expected error: %v, got: %v", jetstream.ErrPinIDMismatch, msgs.Error())
+		}
+		if count != 0 {
+			t.Fatalf("Expected 0 messages, got %d", count)
+		}
+
+		msgs, err = c.Fetch(10, jetstream.FetchMaxWait(500*time.Millisecond), jetstream.FetchPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		for msg := range msgs.Messages() {
+			if msg == nil {
+				break
+			}
+			newId := msg.Headers().Get("Nats-Pin-Id")
+			if newId == id {
+				t.Fatalf("Expected new pull to have different ID. old: %s, new: %s", id, newId)
+			}
+			msg.Ack()
+			count++
+		}
+		if msgs.Error() != nil {
+			t.Fatalf("Unexpected error: %v", msgs.Error())
+		}
+		if count != 10 {
+			t.Fatalf("Expected 10 messages, got %d", count)
+		}
+	})
+}
+
+func TestConsumerUnpin(t *testing.T) {
+	t.Run("unpin consumer", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		c, err := s.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+			Durable:        "cons",
+			AckPolicy:      jetstream.AckExplicitPolicy,
+			Description:    "test consumer",
+			PriorityPolicy: jetstream.PriorityPolicyPinned,
+			PinnedTTL:      50 * time.Second,
+			PriorityGroups: []string{"A"},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		for range 1000 {
+			_, err = js.Publish(ctx, "FOO.bar", []byte("hello"))
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		msgs, err := c.Messages(jetstream.PullPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer msgs.Stop()
+
+		msg, err := msgs.Next()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		firstPinID := msg.Headers().Get("Nats-Pin-Id")
+		if firstPinID == "" {
+			t.Fatalf("Expected pinned message")
+		}
+
+		second, err := s.Consumer(ctx, "cons")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		noMsgs, err := second.Messages(jetstream.PullPriorityGroup("A"))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer noMsgs.Stop()
+
+		done := make(chan struct{})
+		errC := make(chan error)
+		go func() {
+			_, err := noMsgs.Next()
+			if err != nil {
+				errC <- err
+				return
+			}
+			done <- struct{}{}
+		}()
+
+		select {
+		case <-done:
+			t.Fatalf("Expected no message")
+		case <-time.After(500 * time.Millisecond):
+			noMsgs.Stop()
+		}
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Expected error")
+		case err := <-errC:
+			if !errors.Is(err, jetstream.ErrMsgIteratorClosed) {
+				t.Fatalf("Expected error: %v, got: %v", jetstream.ErrMsgIteratorClosed, err)
+			}
+		}
+
+		third, err := s.Consumer(ctx, "cons")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		yesMsgs, err := third.Messages(jetstream.PullPriorityGroup("A"), jetstream.PullExpiry(time.Second))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer yesMsgs.Stop()
+
+		go func() {
+			msg, err := yesMsgs.Next()
+			newPinID := msg.Headers().Get("Nats-Pin-Id")
+			if newPinID == firstPinID || newPinID == "" {
+				errC <- fmt.Errorf("Expected new pin ID, got %s", newPinID)
+				return
+			}
+			if err != nil {
+				errC <- err
+				return
+			}
+			done <- struct{}{}
+		}()
+
+		err = s.UnpinConsumer(ctx, "cons", "A")
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		select {
+		case <-done:
+		case err := <-errC:
+			t.Fatalf("Unexpected error: %v", err)
+		case <-time.After(4 * time.Second):
+			t.Fatalf("Should not time out")
+		}
+	})
+	t.Run("consumer not found", func(t *testing.T) {
+		srv := RunBasicJetStreamServer()
+		defer shutdownJSServerAndRemoveStorage(t, srv)
+
+		nc, err := nats.Connect(srv.ClientURL())
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		defer nc.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		js, err := jetstream.New(nc)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		s, err := js.CreateStream(ctx, jetstream.StreamConfig{Name: "foo", Subjects: []string{"FOO.*"}})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// try unpinning consumer with invalid name
+		err = s.UnpinConsumer(ctx, "cons", "A")
+		if !errors.Is(err, jetstream.ErrConsumerNotFound) {
+			t.Fatalf("Expected error: %v, got: %v", jetstream.ErrConsumerNotFound, err)
 		}
 	})
 }

--- a/jetstream/test/publish_test.go
+++ b/jetstream/test/publish_test.go
@@ -774,6 +774,41 @@ func TestPublish(t *testing.T) {
 	}
 }
 
+func TestPublishTimeout(t *testing.T) {
+	srv := RunBasicJetStreamServer()
+	defer shutdownJSServerAndRemoveStorage(t, srv)
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	js, err := jetstream.New(nc, jetstream.WithDefaultTimeout(200*time.Millisecond))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer nc.Close()
+
+	// create stream with no ack to force timeout
+	_, err = js.CreateStream(context.Background(), jetstream.StreamConfig{
+		Name:     "foo",
+		Subjects: []string{"FOO.*"},
+		NoAck:    true,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	now := time.Now()
+	_, err = js.Publish(context.Background(), "FOO.1", []byte("msg"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Expected deadline exceeded error; got: %v", err)
+	}
+	since := time.Since(now)
+	if since < 200*time.Millisecond || since > 500*time.Millisecond {
+		t.Fatalf("Expected timeout to be around 200ms; got: %v", since)
+	}
+}
+
 func TestPublishMsgAsync(t *testing.T) {
 	type publishConfig struct {
 		msg              *nats.Msg

--- a/jetstream/test/stream_test.go
+++ b/jetstream/test/stream_test.go
@@ -388,6 +388,11 @@ func TestConsumer(t *testing.T) {
 			durable:   "dur.123",
 			withError: jetstream.ErrInvalidConsumerName,
 		},
+		{
+			name:      "empty consumer name",
+			durable:   "",
+			withError: jetstream.ErrInvalidConsumerName,
+		},
 	}
 
 	srv := RunBasicJetStreamServer()

--- a/js.go
+++ b/js.go
@@ -3145,12 +3145,11 @@ func (sub *Subscription) Fetch(batch int, opts ...PullOpt) ([]*Msg, error) {
 		go func() {
 			select {
 			case <-ctx.Done():
-				return
 			case <-connStatusChanged:
 				disconnected.Store(true)
 				cancel()
-				return
 			}
+			nc.RemoveStatusListener(connStatusChanged)
 		}()
 		err = sendReq()
 		for err == nil && len(msgs) < batch {
@@ -3404,12 +3403,11 @@ func (sub *Subscription) FetchBatch(batch int, opts ...PullOpt) (MessageBatch, e
 	go func() {
 		select {
 		case <-ctx.Done():
-			return
 		case <-connStatusChanged:
 			disconnected.Store(true)
 			cancel()
-			return
 		}
+		nc.RemoveStatusListener(connStatusChanged)
 	}()
 	requestBatch := batch - len(result.msgs)
 	req := nextRequest{

--- a/jserrors.go
+++ b/jserrors.go
@@ -164,6 +164,10 @@ var (
 	// ErrTooManyStalledMsgs is returned when too many outstanding async
 	// messages are waiting for ack.
 	ErrTooManyStalledMsgs JetStreamError = &jsError{message: "stalled with too many outstanding async published messages"}
+
+	// ErrFetchDisconnected is returned when the connection to the server is lost
+	// while waiting for messages to be delivered on PullSubscribe.
+	ErrFetchDisconnected = &jsError{message: "disconnected during fetch"}
 )
 
 // Error code represents JetStream error codes returned by the API

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.41.0"
+	Version                   = "1.41.1"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60

--- a/nats.go
+++ b/nats.go
@@ -2844,6 +2844,16 @@ func (nc *Conn) doReconnect(err error, forceReconnect bool) {
 	var rt *time.Timer
 	// Channel used to kick routine out of sleep when conn is closed.
 	rqch := nc.rqch
+
+	// if rqch is nil, we need to set it up to signal
+	// the reconnect loop to reconnect immediately
+	// this means that `ForceReconnect` was called
+	// before entering doReconnect
+	if rqch == nil {
+		rqch = make(chan struct{})
+		close(rqch)
+	}
+
 	// Counter that is increased when the whole list of servers has been tried.
 	var wlf int
 

--- a/nats.go
+++ b/nats.go
@@ -47,7 +47,7 @@ import (
 
 // Default Constants
 const (
-	Version                   = "1.40.1"
+	Version                   = "1.41.0"
 	DefaultURL                = "nats://127.0.0.1:4222"
 	DefaultPort               = 4222
 	DefaultMaxReconnect       = 60

--- a/nats.go
+++ b/nats.go
@@ -2224,6 +2224,7 @@ func (nc *Conn) ForceReconnect() error {
 		// even if we're in the middle of a backoff
 		if nc.rqch != nil {
 			close(nc.rqch)
+			nc.rqch = nil
 		}
 		return nil
 	}

--- a/object.go
+++ b/object.go
@@ -1127,6 +1127,10 @@ func (obs *obs) Watch(opts ...WatchOpt) (ObjectWatcher, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Set us up to close when the waitForMessages func returns.
+	sub.pDone = func(_ string) {
+		close(w.updates)
+	}
 	w.sub = sub
 	return w, nil
 }


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `92def3b..7bfd96a`
**Files Changed:** 28 (25 programming files)
**Programming Ratio:** 89.3%

**Commits included:**
- [FIXED] Add RemoveStatusListener method and fixFetch memory leak (#1856)
- Release v1.41.1 (#1851)
- [FIXED] Use default timeout for ObjectStore.Get when no deadline is set on ctx (#1850)
- [IMPROVED] Remove `golang.org/x/text` dependency (#1849)
- Release v1.41.0 (#1847)
- [FIXED] Ensure object watcher stop closes the updates channel (#1844)
- [ADDED] Consumer groups with Pinned and Overflow (#1826)
- [FIXED] Invalid default in documentation for OrderedConsumerConfig.InactiveThreshold (#1845)
- [ADDED] DefaultTimeout option for JetStream API requests (#1843)
- [FIXED] Initialize rqch channel for immediate reconnection on ForceReconnect (#1846)
... and 5 more commits